### PR TITLE
Add addtoindex key

### DIFF
--- a/mmacells.sty
+++ b/mmacells.sty
@@ -293,6 +293,7 @@
     intype      .bool_set:N = \l_mmacells_intype_bool,
     indexed     .bool_set:N = \l_mmacells_indexed_bool,
     index       .code:n = \int_gset:Nn \g_mmacells_index_int { #1 - 1 },
+    addtoindex  .code:n = \int_gadd:Nn \g_mmacells_index_int { #1 },
     
     fv   .clist_set:N = \l_mmacells_fv_keyval_clist,
     fv*  .code:n = \clist_put_right:Nn \l_mmacells_fv_keyval_clist { #1 },


### PR DESCRIPTION
Takes integer that will be added to current cell index.

Using `addtoindex` should be preferred to using `index` when purpose of manual
index tweaking is compensation of `Null` returning line (i.e. situation in
which cell index in FronEnd is incremented, but no output cell is produced).
