### PR TITLE
Annotations automation

### DIFF
--- a/mmacells.sty
+++ b/mmacells.sty
@@ -260,12 +260,10 @@
     postwidelabel .initial:n = { \leavevmode \@nobreaktrue \parskip=0pt },
     
     formatline .code:n =
-      \cs_set:Npn \mmacells_format_line_wrapper:n ##1 { #1 { ##1 } },
+      \mmacells_set_formatting_function:nn { line_wrapper } { #1 },
     
-    labelstyle     .code:n =
-      \cs_set:Npn \mmacells_format_label:n ##1 { #1 { ##1 } },
-    linkstyle     .code:n =
-      \cs_set:Npn \mmacells_format_link:n ##1 { #1 { ##1 } },
+    labelstyle .code:n = \mmacells_set_formatting_function:nn { label } { #1 },
+    linkstyle  .code:n = \mmacells_set_formatting_function:nn { link } { #1 },
     
     linklocaluri .code:n =
       \cs_set:Npn \mmacells_link_local_uri:n ##1 { #1 },

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -42,19 +42,6 @@
     \tl_use:N \l_mmacells_form_tl
   }
 
-\NewDocumentCommand \mmaDef { m }
-  { \mmacells_typeset_formatted:Nn \mmacells_format_defined:n { #1 } }
-\NewDocumentCommand \mmaUnd { m }
-  { \mmacells_typeset_formatted:Nn \mmacells_format_undefined:n { #1 } }
-\NewDocumentCommand \mmaDyn { m }
-  { \mmacells_typeset_formatted:Nn \mmacells_format_dynamic:n { #1 } }
-\NewDocumentCommand \mmaLex { m }
-  { \mmacells_typeset_formatted:Nn \mmacells_format_lexical:n { #1 } }
-\NewDocumentCommand \mmaArg { m }
-  { \mmacells_typeset_formatted:Nn \mmacells_format_argument:n { #1 } }
-\NewDocumentCommand \mmaErr { m }
-  { \mmacells_typeset_formatted:Nn \mmacells_format_error:n { #1 } }
-
 
 \NewDocumentCommand \mmaLinkTarget { s o m }
   {
@@ -91,6 +78,28 @@
       }
   }
 
+\NewDocumentCommand \mmaDefineAnnotation { o m }
+  {
+    \IfValueTF { #1 }
+      {
+        \mmacells_define_annotation:nnnnV
+          { #1 } { #2 } { emph } { } \g_mmacells_next_emph_class_int
+      }
+      {
+        \mmacells_define_annotation:nnnnV
+          { #2 } { #2 } { emph } { } \g_mmacells_next_emph_class_int
+      }
+    \int_gincr:N \g_mmacells_next_emph_class_int
+  }
+
+\NewDocumentCommand \mmaDefineFrontEndInStyle { O{MathematicaFrontEndIn} m }
+  {
+    \clist_put_right:Nn \l_mmacells_frontendin_style_lst_keyval_clist { #2 }
+    
+    \mmacells_lst_define_style:nV { #1 }
+      \l_mmacells_frontendin_style_lst_keyval_clist
+  }
+
 \NewDocumentCommand \mmaDefineCellStyle { m m }
   { \mmacells_define_style:nn { #1 } { #2 } }
 
@@ -103,6 +112,7 @@
 
 
 \int_new:N \g_mmacells_index_int
+\int_new:N \g_mmacells_next_emph_class_int
 \bool_new:N \g_mmacells_previous_intype_bool
 
 \bool_new:N \l_mmacells_indexed_bool
@@ -120,6 +130,9 @@
 \clist_new:N \l_mmacells_lst_keyval_clist
 \clist_new:N \l_mmacells_fv_keyval_clist
 \clist_new:N \l_mmacells_graphics_keyval_clist
+\clist_new:N \l_mmacells_annotations_lst_keyval_clist
+\clist_new:N \l_mmacells_formatted_lst_keyval_clist
+\clist_new:N \l_mmacells_frontendin_style_lst_keyval_clist
 
 \box_new:N \l_mmacells_label_box
 
@@ -132,12 +145,6 @@
 \cs_new_nopar:Npn \mmacells_post_wide_label: { }
 
 \cs_new:Npn \mmacells_format_line_wrapper:n #1 { #1 }
-\cs_new:Npn \mmacells_format_defined:n #1 { #1 }
-\cs_new:Npn \mmacells_format_undefined:n #1 { #1 }
-\cs_new:Npn \mmacells_format_dynamic:n #1 { #1 }
-\cs_new:Npn \mmacells_format_lexical:n #1 { #1 }
-\cs_new:Npn \mmacells_format_argument:n #1 { #1 }
-\cs_new:Npn \mmacells_format_error:n #1 { #1 }
 \cs_new:Npn \mmacells_format_label:n #1 { #1 }
 \cs_new:Npn \mmacells_format_link:n #1 { #1 }
 
@@ -152,6 +159,43 @@
 \cs_new_nopar:Npn \__mmacells_end_verbatimenv: { }
 \cs_set_nopar:Npn \__mmacells_add_math_replacements: { }
 
+
+\cs_new_protected:Npn \mmacells_define_annotation:nnnnn #1#2#3#4#5
+  {
+    \exp_args:Nc \NewDocumentCommand { mma#1 } { m }
+      { \mmacells_typeset_formatted:cn { mmacells_format_#2:n } { ##1 } }
+    
+    \cs_new:cpn { mmacells_format_#2:n } ##1 { ##1 }
+    
+    \keys_define:nn { mmacells }
+      {
+        #2style .code:n = \mmacells_set_formatting_function:nn { #2 } { ##1 },
+      }
+    
+    \mmacells_define_annotation_keys:nnnnnn
+      { #1 } { } { #2 } { #3 } { #4 } { #5 }
+  }
+\cs_generate_variant:Nn \mmacells_define_annotation:nnnnn { nnnnV }
+
+\cs_new_protected:Npn \mmacells_define_annotation_keys:nnnnnn #1#2#3#4#5#6
+  {
+    \keys_define:nn { mmacells }
+      {
+        #3       .meta:n = { lst* = { #4#5       = {[#6] ##1 } } },
+        #3*      .meta:n = { lst* = { more#4#5   = {[#6] ##1 } } },
+      }
+    \__mmacells_clist_put_right:Nncn
+      \l_mmacells_frontendin_style_lst_keyval_clist
+      { #4style=[#6] } { mma#1 } { #2 }
+    
+    \__mmacells_clist_put_right:Nncn \l_mmacells_annotations_lst_keyval_clist
+      { moredelim=[is][ } { mma#1 } { #2]{\\mma#1\{}{\}} }
+    
+    \__mmacells_clist_put_right:Nncn \l_mmacells_formatted_lst_keyval_clist
+      { morefvcmdparams= } { mma#1 } { 1 }
+  }
+
+
 \cs_new_protected_nopar:Npn \mmacells_prepare_verbatimenv:
   {
     \bool_if:NT \l_mmacells_formatted_bool
@@ -161,22 +205,7 @@
             commandchars=\\\{\},
             formatcom*={\everymath{\displaystyle}},
           }
-        \mmacells_lst_set:n
-          {
-            morefvcmdparams=\mmaDef 1,
-            morefvcmdparams=\mmaUnd 1,
-            morefvcmdparams=\mmaDyn 1,
-            morefvcmdparams=\mmaLex 1,
-            morefvcmdparams=\mmaArg 1,
-            morefvcmdparams=\mmaErr 1,
-            morefvcmdparams=\mmaLinkTarget 1,
-            morefvcmdparams=\mmaLinkLocal 1,
-            morefvcmdparams=\mmaLinkBuiltin 1,
-            morefvcmdparams=\big 1,
-            morefvcmdparams=\Big 1,
-            morefvcmdparams=\bigg 1,
-            morefvcmdparams=\Bigg 1,
-          }
+        \mmacells_lst_set:V \l_mmacells_formatted_lst_keyval_clist
       }
 
     \bool_if:NT \l_mmacells_message_link_literate_bool
@@ -219,22 +248,9 @@
     \mmacells_lst_set:V \l_mmacells_lst_keyval_clist
     
     \bool_if:NT \l_mmacells_annotations_bool
-      {
-        \mmacells_lst_set:n
-          {
-            moredelim=[is][\mmaDef]{\\mmaDef\{}{\}},
-            moredelim=[is][\mmaUnd]{\\mmaUnd\{}{\}},
-            moredelim=[is][\mmaDyn]{\\mmaDyn\{}{\}},
-            moredelim=[is][\mmaLex]{\\mmaLex\{}{\}},
-            moredelim=[is][\mmaArg]{\\mmaArg\{}{\}},
-            moredelim=[is][\mmaErr]{\\mmaErr\{}{\}},
-            moredelim=[is][\mmaLinkTarget*]{\\mmaLinkTarget\{}{\}},
-            moredelim=[is][\mmaLinkLocal*]{\\mmaLinkLocal\{}{\}},
-            moredelim=[is][\mmaLinkBuiltin*]{\\mmaLinkBuiltin\{}{\}},
-          }
-      }
+      { \mmacells_lst_set:V \l_mmacells_annotations_lst_keyval_clist }
               
-      \__mmacells_wrap_fv_formatline:n { \mmacells_format_line_wrapper:n }
+    \__mmacells_wrap_fv_formatline:n { \mmacells_format_line_wrapper:n }
 
     \VerbatimEnvironment
   }
@@ -264,18 +280,6 @@
     formatline .code:n =
       \cs_set:Npn \mmacells_format_line_wrapper:n ##1 { #1 { ##1 } },
     
-    definedstyle   .code:n =
-      \cs_set:Npn \mmacells_format_defined:n ##1 { #1 { ##1 } },
-    undefinedstyle .code:n =
-      \cs_set:Npn \mmacells_format_undefined:n ##1 { #1 { ##1 } },
-    dynamicstyle   .code:n =
-      \cs_set:Npn \mmacells_format_dynamic:n ##1 { #1 { ##1 } },
-    lexicalstyle   .code:n =
-      \cs_set:Npn \mmacells_format_lexical:n ##1 { #1 { ##1 } },
-    argumentstyle  .code:n =
-      \cs_set:Npn \mmacells_format_argument:n ##1 { #1 { ##1 } },
-    errorstyle  .code:n =
-      \cs_set:Npn \mmacells_format_error:n ##1 { #1 { ##1 } },
     labelstyle     .code:n =
       \cs_set:Npn \mmacells_format_label:n ##1 { #1 { ##1 } },
     linkstyle     .code:n =
@@ -306,17 +310,6 @@
     graphics* .code:n = 
       \clist_put_right:Nn \l_mmacells_graphics_keyval_clist { #1 },
     
-    defined      .meta:n = { lst* = { keywords = { #1 } } },
-    defined*     .meta:n = { lst* = { morekeywords = { #1 } } },
-    undefined    .meta:n = { lst* = { deletekeywords = { #1 } } },
-    dynamic      .meta:n = { lst* = { emph = {[1] #1 } } },
-    dynamic*     .meta:n = { lst* = { moreemph = {[1] #1 } } },
-    lexical      .meta:n = { lst* = { emph = {[2] #1 } } },
-    lexical*     .meta:n = { lst* = { moreemph = {[2] #1 } } },
-    argument     .meta:n = { lst* = { emph = {[3] #1 } } },
-    argument*    .meta:n = { lst* = { moreemph = {[3] #1 } } },
-    error        .meta:n = { lst* = { emph = {[4] #1 } } },
-    error*       .meta:n = { lst* = { moreemph = {[4] #1 } } },
     linktarget   .meta:n = { lst* = { emph = {[5] #1 } } },
     linktarget*  .meta:n = { lst* = { moreemph = {[5] #1 } } },
     linklocal    .meta:n = { lst* = { emph = {[6] #1 } } },
@@ -429,7 +422,10 @@
     #1 { #2 }
     \group_end:
   }
-\cs_generate_variant:Nn \mmacells_typeset_formatted:Nn { NV }
+\cs_generate_variant:Nn \mmacells_typeset_formatted:Nn { NV , cn }
+
+\cs_new_protected:Npn \mmacells_set_formatting_function:nn #1#2
+  { \cs_set:cpn { mmacells_format_#1:n } ##1 { #2 { ##1 } } }
 
 \cs_new_eq:NN \mmacells_fv_set:n \fvset
 \cs_generate_variant:Nn \mmacells_fv_set:n { V }
@@ -440,6 +436,9 @@
 \cs_new_protected:Npn \mmacells_lst_set_literate:n #1
   { \mmacells_lst_set:n { literate = { #1 } } }
 \cs_generate_variant:Nn \mmacells_lst_set_literate:n { V }
+
+\cs_new_eq:NN \mmacells_lst_define_style:nn \lstdefinestyle
+\cs_generate_variant:Nn \mmacells_lst_define_style:nn { nV }
 
 \cs_new:Npn \mmacells_includegraphics:nn #1#2
   { \includegraphics [ #1 ] { #2 } }
@@ -500,6 +499,38 @@
     \cs_set_eq:NN \lstFV@FancyVerbFormatLine \FancyVerbFormatLine
   }
 
+\cs_new_protected:Npn \__mmacells_clist_put_right:Nncn #1#2#3#4
+  {
+    \tl_set:Nn \l_tmpa_tl { #2 }
+    \exp_args:NNc \tl_put_right:Nn \l_tmpa_tl { #3 }
+    \tl_put_right:Nn \l_tmpa_tl { #4 }
+    \clist_put_right:NV #1 \l_tmpa_tl
+  }
+
+
+\clist_set:Nn \l_mmacells_annotations_lst_keyval_clist
+  {
+    moredelim=[is][\mmaLinkTarget*]{\\mmaLinkTarget\{}{\}},
+    moredelim=[is][\mmaLinkLocal*]{\\mmaLinkLocal\{}{\}},
+    moredelim=[is][\mmaLinkBuiltin*]{\\mmaLinkBuiltin\{}{\}},
+  }
+
+\clist_set:Nn \l_mmacells_formatted_lst_keyval_clist
+  {
+    morefvcmdparams=\mmaLinkTarget 1,
+    morefvcmdparams=\mmaLinkLocal 1,
+    morefvcmdparams=\mmaLinkBuiltin 1,
+    morefvcmdparams=\big 1,
+    morefvcmdparams=\Big 1,
+    morefvcmdparams=\bigg 1,
+    morefvcmdparams=\Bigg 1,
+  }
+
+
+\mmacells_define_annotation:nnnnn
+  { Def } { defined } { keyword } { s } { 1 }
+
+
 \makeatother
 \ExplSyntaxOff
 
@@ -528,6 +559,14 @@
 \NewDocumentCommand \mmaSqrt { m } {\ensuremath{\sqrt{#1}}}
 % RadicalBox
 \NewDocumentCommand \mmaRadical { m m } {\ensuremath{\sqrt[\text{#2}]{#1}}}
+
+
+\mmaDefineAnnotation[Und]{undefined}
+\mmaDefineAnnotation[Dyn]{dynamic}
+\mmaDefineAnnotation[Lex]{lexical}
+\mmaDefineAnnotation[Arg]{argument}
+\mmaDefineAnnotation[Err]{error}
+
 
 \mmaSet{
   lst={
@@ -578,17 +617,12 @@
   identifierstyle=,
   emphstyle=,
 }
-\lstdefinestyle{MathematicaFrontEndIn}{
+\mmaDefineFrontEndInStyle{
   style=MathematicaFrontEnd,
   basicstyle=\normalfont\color{black}\ttfamily\bfseries,
-  keywordstyle=\mmaDef,
   stringstyle=\color{mmaString},
   commentstyle=\color{mmaComment},
   identifierstyle=\mmaUnd,
-  emphstyle={[1]\mmaDyn},% Block, Table, ...
-  emphstyle={[2]\mmaLex}, % Module, With
-  emphstyle={[3]\mmaArg}, % arguments in functions and rules
-  emphstyle={[4]\mmaErr}, % errors
   emphstyle={[5]\mmaLinkTarget*}, % local links targets
   emphstyle={[6]\mmaLinkLocal*}, % links to local targets
   emphstyle={[7]\mmaLinkBuiltin*}, % links to builtin symbols

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -498,11 +498,11 @@
   { Def } { defined } { keyword } { s } { 1 }
 
 \mmacells_define_link_annotation:nnnnnN
-  { LinkTarget  } { linktarget  } { emph } { } { 1 } \mmacells_link_target:nn
+  { LnT } { linktarget  } { emph } { } { 1 } \mmacells_link_target:nn
 \mmacells_define_link_annotation:nnnnnN
-  { LinkLocal   } { linklocal   } { emph } { } { 2 } \mmacells_link_local:nn
+  { LnL } { linklocal   } { emph } { } { 2 } \mmacells_link_local:nn
 \mmacells_define_link_annotation:nnnnnN
-  { LinkBuiltin } { linkbuiltin } { emph } { } { 3 } \mmacells_link_builtin:nn
+  { LnB } { linkbuiltin } { emph } { } { 3 } \mmacells_link_builtin:nn
 
 \int_gset:Nn \g_mmacells_next_emph_class_int { 4 }
 

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -164,7 +164,8 @@
     \keys_define:nn { mmacells }
       {
         #3       .meta:n = { lst* = { #4#5       = {[#6] ##1 } } },
-        #3*      .meta:n = { lst* = { more#4#5   = {[#6] ##1 } } },
+        more#3   .meta:n = { lst* = { more#4#5   = {[#6] ##1 } } },
+        delete#3 .meta:n = { lst* = { delete#4#5 = {[#6] ##1 } } },
       }
     \__mmacells_clist_put_right:Nncn
       \l_mmacells_frontendin_style_lst_keyval_clist

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -43,41 +43,6 @@
   }
 
 
-\NewDocumentCommand \mmaLinkTarget { s o m }
-  {
-    \IfValueTF { #2 }
-      { \hypertarget { \mmacells_link_local_uri:n { #2 } } { #3 } }
-      {
-        \IfBooleanTF { #1 }
-          {
-            \hypertarget
-              { \mmacells_link_local_uri:n { \mmacells_lst_token: } }
-              { #3 }
-          }
-          { \hypertarget{ \mmacells_link_local_uri:n { #3 } }{ #3 } }
-      }
-  }
-\NewDocumentCommand \mmaLinkLocal { s o m }
-  {
-    \IfValueTF { #2 }
-      { \mmacells_link_local:nn { #2 } { #3 } }
-      {
-        \IfBooleanTF { #1 }
-          { \mmacells_link_local:nn { \mmacells_lst_token: } { #3 } }
-          { \mmacells_link_local:nn { #3 } { #3 } }
-      }
-  }
-\NewDocumentCommand \mmaLinkBuiltin { s o m }
-  {
-    \IfValueTF { #2 }
-      { \mmacells_link_builtin:nn { #2 } { #3 } }
-      {
-        \IfBooleanTF { #1 }
-          { \mmacells_link_builtin:nn { \mmacells_lst_token: } { #3 } }
-          { \mmacells_link_builtin:nn { #3 } { #3 } }
-      }
-  }
-
 \NewDocumentCommand \mmaDefineAnnotation { o m }
   {
     \IfValueTF { #1 }
@@ -176,6 +141,23 @@
       { #1 } { } { #2 } { #3 } { #4 } { #5 }
   }
 \cs_generate_variant:Nn \mmacells_define_annotation:nnnnn { nnnnV }
+
+\cs_new_protected:Npn \mmacells_define_link_annotation:nnnnnN #1#2#3#4#5#6
+  {
+    \exp_args:Nc \NewDocumentCommand { mma#1 } { s o m }
+      {
+        \IfValueTF { ##2 }
+          { #6 { ##2 } { ##3 } }
+          {
+            \IfBooleanTF { ##1 }
+              { #6 { \mmacells_lst_token: } { ##3 } }
+              { #6 { ##3 } { ##3 } }
+          }
+      }
+    
+    \mmacells_define_annotation_keys:nnnnnn
+      { #1 } { * } { #2 } { #3 } { #4 } { #5 }
+  }
 
 \cs_new_protected:Npn \mmacells_define_annotation_keys:nnnnnn #1#2#3#4#5#6
   {
@@ -309,13 +291,6 @@
     graphics  .clist_set:N = \l_mmacells_graphics_keyval_clist,
     graphics* .code:n = 
       \clist_put_right:Nn \l_mmacells_graphics_keyval_clist { #1 },
-    
-    linktarget   .meta:n = { lst* = { emph = {[5] #1 } } },
-    linktarget*  .meta:n = { lst* = { moreemph = {[5] #1 } } },
-    linklocal    .meta:n = { lst* = { emph = {[6] #1 } } },
-    linklocal*   .meta:n = { lst* = { moreemph = {[6] #1 } } },
-    linkbuiltin  .meta:n = { lst* = { emph = {[7] #1 } } },
-    linkbuiltin* .meta:n = { lst* = { moreemph = {[7] #1 } } },
     
     messagelink  .tl_set:N = \l_mmacells_message_link_tl,
     messagelinkliterate .bool_set:N = \l_mmacells_message_link_literate_bool,
@@ -454,8 +429,11 @@
   }
 
 
+\cs_new_protected:Npn \mmacells_link_target:nn #1#2
+  { \hypertarget { \mmacells_link_local_uri:n { #1 } } { #2 } }
+
 \cs_new_protected:Npn \mmacells_link_local:nn #1#2
-  {\__mmacells_link:NNnn \hyperlink \mmacells_link_local_uri:n { #1 } { #2 } }
+  { \__mmacells_link:NNnn \hyperlink \mmacells_link_local_uri:n { #1 } { #2 } }
 \cs_generate_variant:Nn \mmacells_link_local:nn { Vn }
 
 \cs_new_protected:Npn \mmacells_link_builtin:nn #1#2
@@ -508,18 +486,8 @@
   }
 
 
-\clist_set:Nn \l_mmacells_annotations_lst_keyval_clist
-  {
-    moredelim=[is][\mmaLinkTarget*]{\\mmaLinkTarget\{}{\}},
-    moredelim=[is][\mmaLinkLocal*]{\\mmaLinkLocal\{}{\}},
-    moredelim=[is][\mmaLinkBuiltin*]{\\mmaLinkBuiltin\{}{\}},
-  }
-
 \clist_set:Nn \l_mmacells_formatted_lst_keyval_clist
   {
-    morefvcmdparams=\mmaLinkTarget 1,
-    morefvcmdparams=\mmaLinkLocal 1,
-    morefvcmdparams=\mmaLinkBuiltin 1,
     morefvcmdparams=\big 1,
     morefvcmdparams=\Big 1,
     morefvcmdparams=\bigg 1,
@@ -529,6 +497,15 @@
 
 \mmacells_define_annotation:nnnnn
   { Def } { defined } { keyword } { s } { 1 }
+
+\mmacells_define_link_annotation:nnnnnN
+  { LinkTarget  } { linktarget  } { emph } { } { 1 } \mmacells_link_target:nn
+\mmacells_define_link_annotation:nnnnnN
+  { LinkLocal   } { linklocal   } { emph } { } { 2 } \mmacells_link_local:nn
+\mmacells_define_link_annotation:nnnnnN
+  { LinkBuiltin } { linkbuiltin } { emph } { } { 3 } \mmacells_link_builtin:nn
+
+\int_gset:Nn \g_mmacells_next_emph_class_int { 4 }
 
 
 \makeatother
@@ -623,9 +600,6 @@
   stringstyle=\color{mmaString},
   commentstyle=\color{mmaComment},
   identifierstyle=\mmaUnd,
-  emphstyle={[5]\mmaLinkTarget*}, % local links targets
-  emphstyle={[6]\mmaLinkLocal*}, % links to local targets
-  emphstyle={[7]\mmaLinkBuiltin*}, % links to builtin symbols
 }
 
 \mmaDefineCellStyle{Code}{


### PR DESCRIPTION
- Add `\mmaDefineAnnotation` and `\mmaDefineFrontEndInStyle` functions.
- Rename annotation keys: `...*` -> `more...`.
- Also add `delete...` keys.
- Shorten link annotation commands:
  - `\mmaLinkTarget` -> `\mmaLnT`,
  - `\mmaLinkLocal` -> `\mmaLnL`,
  - `\mmaLinkBuiltin` -> `\mmaLnB`.
