### PR TITLE
Match mathematica names

### DIFF
--- a/mmacells.sty
+++ b/mmacells.sty
@@ -542,6 +542,7 @@
 \mmaDefineAnnotation[Loc]{local}
 \mmaDefineAnnotation[Pat]{pattern}
 \mmaDefineAnnotation[Exc]{excessargument}
+\mmaDefineAnnotation[Snt]{syntaxerror}
 \mmaDefineAnnotation[Emp]{emphasizedsyntaxerror}
 \mmaDefineAnnotation[Fmt]{formattingerror}
 
@@ -562,6 +563,7 @@
   localstyle=\color{mmaLocal},
   patternstyle=\color{mmaLocal}\slshape, % or \itshape if supported
   excessargumentstyle=\color{mmaError},
+  syntaxerrorstyle=\color{mmaSyntaxError},
   emphasizedsyntaxerrorstyle={%
     \color{mmaEmphasizedError}\mmaHl{mmaEmphasizedErrorBackground}%
   },
@@ -580,6 +582,7 @@
 \definecolor{mmaLocal}{RGB}{67,137,88}
 \definecolor{mmaMessage}{RGB}{129,43,38}
 \definecolor{mmaError}{RGB}{255,51,51}
+\definecolor{mmaSyntaxError}{RGB}{194,85,204}
 \definecolor{mmaEmphasizedError}{RGB}{204,0,0}
 \definecolor{mmaEmphasizedErrorBackground}{RGB}{255,225,130}
 \definecolor{mmaFormattingError}{RGB}{255,85,85}

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -543,6 +543,7 @@
 \mmaDefineAnnotation[Pat]{pattern}
 \mmaDefineAnnotation[Exc]{excessargument}
 \mmaDefineAnnotation[Emp]{emphasizedsyntaxerror}
+\mmaDefineAnnotation[Fmt]{formattingerror}
 
 
 \NewDocumentCommand \mmaHl { m m }
@@ -564,6 +565,9 @@
   emphasizedsyntaxerrorstyle={%
     \color{mmaEmphasizedError}\mmaHl{mmaEmphasizedErrorBackground}%
   },
+  formattingerrorstyle={%
+    \fboxsep0.3em\fcolorbox{mmaFormattingError}{mmaFormattingErrorBackground}%
+  },
   labelstyle=\normalfont\color{mmaLabel}\sffamily\scriptsize,
   linkstyle=\color{mmaLink},
   linkbuiltinuri=http://reference.wolfram.com/language/ref/#1.html,
@@ -578,6 +582,8 @@
 \definecolor{mmaError}{RGB}{255,51,51}
 \definecolor{mmaEmphasizedError}{RGB}{204,0,0}
 \definecolor{mmaEmphasizedErrorBackground}{RGB}{255,225,130}
+\definecolor{mmaFormattingError}{RGB}{255,85,85}
+\definecolor{mmaFormattingErrorBackground}{RGB}{255,230,230}
 \definecolor{mmaString}{gray}{.4}
 \definecolor{mmaComment}{gray}{.6}
 

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -544,6 +544,7 @@
 \mmaDefineAnnotation[LCn]{localconflict}
 \mmaDefineAnnotation[GCn]{globalconflict}
 \mmaDefineAnnotation[Exc]{excessargument}
+\mmaDefineAnnotation[Opt]{unknownoption}
 \mmaDefineAnnotation[Shd]{shadowing}
 \mmaDefineAnnotation[Snt]{syntaxerror}
 \mmaDefineAnnotation[Emp]{emphasizedsyntaxerror}
@@ -568,6 +569,7 @@
   localconflictstyle=\color{mmaEmphasizedError},
   globalconflictstyle=\color{mmaEmphasizedError},
   excessargumentstyle=\color{mmaError},
+  unknownoptionstyle=\color{mmaError},
   shadowingstyle=\color{mmaError},
   syntaxerrorstyle=\color{mmaSyntaxError},
   emphasizedsyntaxerrorstyle={%

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -542,6 +542,7 @@
 \mmaDefineAnnotation[Loc]{local}
 \mmaDefineAnnotation[Pat]{pattern}
 \mmaDefineAnnotation[LCn]{localconflict}
+\mmaDefineAnnotation[GCn]{globalconflict}
 \mmaDefineAnnotation[Exc]{excessargument}
 \mmaDefineAnnotation[Shd]{shadowing}
 \mmaDefineAnnotation[Snt]{syntaxerror}
@@ -565,6 +566,7 @@
   localstyle=\color{mmaLocal},
   patternstyle=\color{mmaLocal}\slshape, % or \itshape if supported
   localconflictstyle=\color{mmaEmphasizedError},
+  globalconflictstyle=\color{mmaEmphasizedError},
   excessargumentstyle=\color{mmaError},
   shadowingstyle=\color{mmaError},
   syntaxerrorstyle=\color{mmaSyntaxError},

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -545,6 +545,7 @@
 \mmaDefineAnnotation[GCn]{globalconflict}
 \mmaDefineAnnotation[Exc]{excessargument}
 \mmaDefineAnnotation[Opt]{unknownoption}
+\mmaDefineAnnotation[Asg]{unwantedassignment}
 \mmaDefineAnnotation[Shd]{shadowing}
 \mmaDefineAnnotation[Snt]{syntaxerror}
 \mmaDefineAnnotation[Emp]{emphasizedsyntaxerror}
@@ -570,6 +571,7 @@
   globalconflictstyle=\color{mmaEmphasizedError},
   excessargumentstyle=\color{mmaError},
   unknownoptionstyle=\color{mmaError},
+  unwantedassignmentstyle=\color{mmaError},
   shadowingstyle=\color{mmaError},
   syntaxerrorstyle=\color{mmaSyntaxError},
   emphasizedsyntaxerrorstyle={%

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -542,6 +542,7 @@
 \mmaDefineAnnotation[Loc]{local}
 \mmaDefineAnnotation[Pat]{pattern}
 \mmaDefineAnnotation[Exc]{excessargument}
+\mmaDefineAnnotation[Shd]{shadowing}
 \mmaDefineAnnotation[Snt]{syntaxerror}
 \mmaDefineAnnotation[Emp]{emphasizedsyntaxerror}
 \mmaDefineAnnotation[Fmt]{formattingerror}
@@ -563,6 +564,7 @@
   localstyle=\color{mmaLocal},
   patternstyle=\color{mmaLocal}\slshape, % or \itshape if supported
   excessargumentstyle=\color{mmaError},
+  shadowingstyle=\color{mmaError},
   syntaxerrorstyle=\color{mmaSyntaxError},
   emphasizedsyntaxerrorstyle={%
     \color{mmaEmphasizedError}\mmaHl{mmaEmphasizedErrorBackground}%

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -538,10 +538,10 @@
 
 
 \mmaDefineAnnotation[Und]{undefined}
-\mmaDefineAnnotation[Dyn]{dynamic}
-\mmaDefineAnnotation[Lex]{lexical}
-\mmaDefineAnnotation[Arg]{argument}
-\mmaDefineAnnotation[Err]{error}
+\mmaDefineAnnotation[Fnc]{functionlocal}
+\mmaDefineAnnotation[Loc]{local}
+\mmaDefineAnnotation[Pat]{pattern}
+\mmaDefineAnnotation[Exc]{excessargument}
 
 
 \mmaSet{
@@ -553,10 +553,10 @@
   labelsep=.6em,
   definedstyle=\color{black},
   undefinedstyle=\color{mmaUndefined},
-  dynamicstyle=\color{mmaDynamic},
-  lexicalstyle=\color{mmaLexical},
-  argumentstyle=\color{mmaLexical}\slshape, % or \itshape if supported
-  errorstyle=\color{mmaError},
+  functionlocalstyle=\color{mmaFunctionLocal},
+  localstyle=\color{mmaLocal},
+  patternstyle=\color{mmaLocal}\slshape, % or \itshape if supported
+  excessargumentstyle=\color{mmaError},
   labelstyle=\normalfont\color{mmaLabel}\sffamily\scriptsize,
   linkstyle=\color{mmaLink},
   linkbuiltinuri=http://reference.wolfram.com/language/ref/#1.html,
@@ -565,8 +565,8 @@
 \definecolor{mmaLabel}{RGB}{70,70,153}
 \definecolor{mmaLink}{RGB}{20,40,153}
 \definecolor{mmaUndefined}{RGB}{0,44,195}
-\definecolor{mmaDynamic}{RGB}{60,125,145}
-\definecolor{mmaLexical}{RGB}{67,137,88}
+\definecolor{mmaFunctionLocal}{RGB}{60,125,145}
+\definecolor{mmaLocal}{RGB}{67,137,88}
 \definecolor{mmaMessage}{RGB}{129,43,38}
 \definecolor{mmaError}{RGB}{255,51,51}
 \definecolor{mmaString}{gray}{.4}

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -541,6 +541,7 @@
 \mmaDefineAnnotation[Fnc]{functionlocal}
 \mmaDefineAnnotation[Loc]{local}
 \mmaDefineAnnotation[Pat]{pattern}
+\mmaDefineAnnotation[LCn]{localconflict}
 \mmaDefineAnnotation[Exc]{excessargument}
 \mmaDefineAnnotation[Shd]{shadowing}
 \mmaDefineAnnotation[Snt]{syntaxerror}
@@ -563,6 +564,7 @@
   functionlocalstyle=\color{mmaFunctionLocal},
   localstyle=\color{mmaLocal},
   patternstyle=\color{mmaLocal}\slshape, % or \itshape if supported
+  localconflictstyle=\color{mmaEmphasizedError},
   excessargumentstyle=\color{mmaError},
   shadowingstyle=\color{mmaError},
   syntaxerrorstyle=\color{mmaSyntaxError},

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -542,7 +542,11 @@
 \mmaDefineAnnotation[Loc]{local}
 \mmaDefineAnnotation[Pat]{pattern}
 \mmaDefineAnnotation[Exc]{excessargument}
+\mmaDefineAnnotation[Emp]{emphasizedsyntaxerror}
 
+
+\NewDocumentCommand \mmaHl { m m }
+  {{\fboxsep0pt\colorbox{#1}{\strut #2}}}
 
 \mmaSet{
   lst={
@@ -557,6 +561,9 @@
   localstyle=\color{mmaLocal},
   patternstyle=\color{mmaLocal}\slshape, % or \itshape if supported
   excessargumentstyle=\color{mmaError},
+  emphasizedsyntaxerrorstyle={%
+    \color{mmaEmphasizedError}\mmaHl{mmaEmphasizedErrorBackground}%
+  },
   labelstyle=\normalfont\color{mmaLabel}\sffamily\scriptsize,
   linkstyle=\color{mmaLink},
   linkbuiltinuri=http://reference.wolfram.com/language/ref/#1.html,
@@ -569,6 +576,8 @@
 \definecolor{mmaLocal}{RGB}{67,137,88}
 \definecolor{mmaMessage}{RGB}{129,43,38}
 \definecolor{mmaError}{RGB}{255,51,51}
+\definecolor{mmaEmphasizedError}{RGB}{204,0,0}
+\definecolor{mmaEmphasizedErrorBackground}{RGB}{255,225,130}
 \definecolor{mmaString}{gray}{.4}
 \definecolor{mmaComment}{gray}{.6}
 


### PR DESCRIPTION
# Rename annotations to match Mathematica names

Keys:
- `dynamic` -> `functionlocal`,
- `lexical` -> `local`,
- `argument` -> `pattern`,
- `error` -> `excessargument`.

Commands:
- `\mmaDyn` -> `\mmaFnc`,
- `\mmaLex` -> `\mmaLoc`,
- `\mmaArg` -> `\mmaPat`,
- `\mmaErr` -> `\mmaExc`.

Colors:
- `mmaDynamic` -> `mmaFunctionLocal`,
- `mmaLexical` -> `mmaLocal`.
# New supported syntax elements

| Mathematica name | command | key |
| --- | --- | --- |
| LocalScopeConflict | \mmaLCn | localconflict |
| GlobalToLocalScopeConflict | \mmaGCn | globalconflict |
| UnknownOption | \mmaOpt | unknownoption |
| UnwantedAssignment | \mmaAsg | unwantedassignment |
| SymbolShadowing | \mmaShd | shadowing |
| SyntaxError | \mmaSnt | syntaxerror |
| EmphasizedSyntaxError | \mmaEmp | emphasizedsyntaxerror |
| FormattingError | \mmaFmt | formattingerror |

All elements have accompanying `more...`, `delete...` and `...style` keys.
