### PR TITLE
Errors when first cell is formatted

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ on TeX Stack Exchange.
 ## Installation
 
 1. Download latest released
-   [mmacells.sty](https://raw.githubusercontent.com/jkuczm/mmacells/v0.1.0/mmacells.sty)
+   [mmacells.sty](https://raw.githubusercontent.com/jkuczm/mmacells/v0.1.1/mmacells.sty)
    file.
 
 2. Put it someplace [where your TeX distribution can find it](http://tex.stackexchange.com/q/1137/70587).

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -13,7 +13,7 @@
 
 \RequirePackage{expl3,xparse}
 
-\ProvidesExplPackage {mmacells} {2015/03/05} {0.1.0}
+\ProvidesExplPackage {mmacells} {2015/03/06} {0.1.1}
   {Mathematica front end cells}
 
 \RequirePackage{amsmath,bbm}

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -662,7 +662,7 @@
   deletekeywords=[2]$, % $ is not a keyword.
   morekeywords={@,_},
   keywordsprefix=_, % Blank... patterns with head
-}
+}[keywords,comments,strings,fancyvrb]
 \lstdefinestyle{MathematicaFrontEnd}{
   showstringspaces=false,
   columns=fullflexible,


### PR DESCRIPTION
When first used cell was a `formatted` one, an error was printed, informing about undefined key: `morefvcmdparams`.

It seems listings `fancyvrb` aspect is loaded automatically only when `fancyvrb` key is used, but not when other keys defined in this aspect are used.

Fixed by explicitly requiring `fancyvrb` aspect in `base` `Mathematica` language definition.
