### PR TITLE
Inline cells

### DIFF
--- a/mmacells.sty
+++ b/mmacells.sty
@@ -200,16 +200,19 @@
   }
 
 
-\cs_new_protected_nopar:Npn \mmacells_prepare_verbatimenv:
+\cs_new_protected_nopar:Npn \__mmacells_prepare_verbatim_keyval:
   {
     \bool_if:NT \l_mmacells_formatted_bool
       {
-        \mmacells_fv_set:n
+        \clist_put_left:Nn
+          \l_mmacells_fv_keyval_clist
           {
             commandchars=\\\{\},
             formatcom*={\everymath{\displaystyle}},
           }
-        \mmacells_lst_set:V \l_mmacells_formatted_lst_keyval_clist
+        \clist_put_left:NV
+          \l_mmacells_lst_keyval_clist
+          \l_mmacells_formatted_lst_keyval_clist
       }
 
     \bool_if:NT \l_mmacells_message_link_literate_bool
@@ -245,14 +248,26 @@
     
     \__mmacells_add_math_replacements:
     
-    \mmacells_fv_set:n { formatcom* = \__mmacells_fix_labels: }
-    \mmacells_fv_set:V \l_mmacells_fv_keyval_clist
-
-    \mmacells_lst_set_literate:V \l_mmacells_lst_literate_tl
-    \mmacells_lst_set:V \l_mmacells_lst_keyval_clist
+    \tl_set_eq:NN \l_tmpa_tl \l_mmacells_lst_literate_tl
+    \tl_put_left:Nn \l_tmpa_tl { literate = }
+    \clist_put_left:NV \l_mmacells_lst_keyval_clist \l_tmpa_tl
     
     \bool_if:NT \l_mmacells_annotations_bool
-      { \mmacells_lst_set:V \l_mmacells_annotations_lst_keyval_clist }
+      {
+        \clist_put_right:NV
+          \l_mmacells_lst_keyval_clist
+          \l_mmacells_annotations_lst_keyval_clist
+      }
+  }
+
+\cs_new_protected_nopar:Npn \mmacells_prepare_verbatimenv:
+  {
+    \__mmacells_prepare_verbatim_keyval:
+
+    \mmacells_lst_set:V \l_mmacells_lst_keyval_clist
+
+    \mmacells_fv_set:n { formatcom* = \__mmacells_fix_labels: }
+    \mmacells_fv_set:V \l_mmacells_fv_keyval_clist
               
     \__mmacells_wrap_fv_formatline:n { \mmacells_format_line_wrapper:n }
 
@@ -453,10 +468,6 @@
 
 \cs_new_eq:NN \mmacells_lst_set:n \lstset
 \cs_generate_variant:Nn \mmacells_lst_set:n { V }
-
-\cs_new_protected:Npn \mmacells_lst_set_literate:n #1
-  { \mmacells_lst_set:n { literate = { #1 } } }
-\cs_generate_variant:Nn \mmacells_lst_set_literate:n { V }
 
 \cs_new_eq:NN \mmacells_lst_define_style:nn \lstdefinestyle
 \cs_generate_variant:Nn \mmacells_lst_define_style:nn { nV }

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -30,6 +30,12 @@
 \NewDocumentCommand \mmaCellGraphics { O{} m m }
   { \mmacells_cell_graphics:nnn { #1 } { #2 } { #3 } }
 
+\NewDocumentCommand \mmaInlineCell { O{} m v }
+  { \mmacells_inline_cell:nnn { #1 } { #2 } { #3 } }
+
+\NewDocumentCommand \mmaInlineCellNonVerb { O{} m m }
+  { \mmacells_inline_cell:nnn { #1 } { #2 } { #3 } }
+
 \NewDocumentCommand \mmaSet { m }
   { \keys_set:nn { mmacells } { #1 } }
 
@@ -425,6 +431,31 @@
     \mmacells_includegraphics_coffin:n { #2 }
   }
 
+\cs_new_protected:Npn \mmacells_inline_cell:nnn #1#2#3
+  {
+    \leavevmode
+    \group_begin:
+    \keys_set:nn { mmacells } { style={#2}, #1 }
+    \__mmacells_prepare_verbatim_keyval:
+    
+    \bool_if:NTF \l_mmacells_formatted_bool
+      {
+        \mmacells_fv_set:V \l_mmacells_fv_keyval_clist
+        \__mmacells_fv_formatting_prep:
+        \tl_set_rescan:Nnn \l_tmpa_tl { \__mmacells_fv_cat_codes: } { #3 }
+      }
+      { \tl_set:Nn \l_tmpa_tl { #3 } }
+    
+    \__mmacells_lst_hook_pre_set:
+    \mmacells_lst_set:V \l_mmacells_lst_keyval_clist
+    \__mmacells_lst_hook_text_style:
+    \__mmacells_lst_init:n { \relax }
+    \__mmacells_lst_fv_format_inline:V \l_tmpa_tl
+    \__mmacells_lst_deinit:
+    
+    \group_end:
+  }
+
 \cs_new_protected_nopar:Npn \mmacells_handle_index:
   {
     \bool_if:NT \l_mmacells_indexed_bool
@@ -518,6 +549,30 @@
       }
     \group_end:
   }
+
+
+\cs_new_eq:NN \__mmacells_fv_formatting_prep: \FV@FormattingPrep
+\cs_new_eq:NN \__mmacells_fv_cat_codes: \FV@CatCodes
+
+% Copy of \lstFV@FancyVerbFormatLine adapted to inline listings.
+\cs_new:Npn \__mmacells_lst_fv_format_inline:n #1
+  {
+    \cs_set_eq:NN \lst@arg \@empty
+    \lst@FVConvert#1\@nil
+    \lst@ReenterModes
+    \lst@arg
+    \lst@PrintToken
+    \lst@InterruptModes
+  }
+\cs_generate_variant:Nn \__mmacells_lst_fv_format_inline:n { V }
+
+\cs_new_eq:NN \__mmacells_lst_init:n \lst@Init
+
+\cs_new_eq:NN \__mmacells_lst_deinit: \lst@DeInit
+
+\cs_new_nopar:Npn \__mmacells_lst_hook_pre_set: { \lsthk@PreSet }
+
+\cs_new_nopar:Npn \__mmacells_lst_hook_text_style: { \lsthk@TextStyle }
 
 \cs_new_nopar:Npn \mmacells_lst_token: { \the \lst@token }
 


### PR DESCRIPTION
- Add `\mmaInlineCell` function that can be used to put Mathematica cells inside text.
- Add `\mmaInlineCellNonVerb` a non-verbatim variant that can be used inside macro arguments.
- Add `\mmacells_inline_cell:nnn` function used to implement above two user level functions.
- Remove `\mmacells_lst_set_literate:n`.
- Add `\__mmacells_prepare_verbatim_keyval:`.
