### PR TITLE
Fix pattern variables in math mode

### DIFF
--- a/mmacells.sty
+++ b/mmacells.sty
@@ -711,7 +711,7 @@
   undefinedstyle=\color{mmaUndefined},
   functionlocalstyle=\color{mmaFunctionLocal},
   localstyle=\color{mmaLocal},
-  patternstyle=\color{mmaLocal}\slshape, % or \itshape if supported
+  patternstyle=\color{mmaLocal}\textsl, % or \textit if supported
   localconflictstyle=\color{mmaEmphasizedError},
   globalconflictstyle=\color{mmaEmphasizedError},
   excessargumentstyle=\color{mmaError},


### PR DESCRIPTION
Use `\textsl` instead of `\slshape` in default style of pattern variables, so that they can be used inside math mode.
