### PR TITLE
Handle `@` sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ on TeX Stack Exchange.
 ## Installation
 
 1. Download latest released
-   [mmacells.sty](https://raw.githubusercontent.com/jkuczm/mmacells/v0.3.0/mmacells.sty)
+   [mmacells.sty](https://raw.githubusercontent.com/jkuczm/mmacells/v0.3.1/mmacells.sty)
    file.
 
 2. Put it someplace [where your TeX distribution can find it](http://tex.stackexchange.com/q/1137/70587).

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -817,11 +817,12 @@
 \definecolor{mmaComment}{gray}{.6}
 
 \lstdefinelanguage[base]{Mathematica}[5.2]{Mathematica}{
-  alsoletter={\#}, % It's used in Slot identifier names.
+  alsoletter={\#}, % # is used in Slot identifier names.
+  alsoother={@}, % @ is an operator.
   morestring=[b]", % " inside string is escaped by backslash.
   morecomment=[n]{(*}{*)}, % Mathematica comments can be nested.
   deletekeywords=[2]$, % $ is not a keyword.
-  morekeywords={@,_},
+  morekeywords={_},
   keywordsprefix=_, % Blank... patterns with head
 }[keywords,comments,strings,fancyvrb]
 \lstdefinestyle{MathematicaFrontEnd}{

--- a/mmacells.sty
+++ b/mmacells.sty
@@ -13,7 +13,7 @@
 
 \RequirePackage{expl3,xparse}
 
-\ProvidesExplPackage {mmacells} {2016/05/20} {0.3.0}
+\ProvidesExplPackage {mmacells} {2016/06/26} {0.3.1}
   {Mathematica front end cells}
 
 \RequirePackage{amsmath,bbm}


### PR DESCRIPTION
Make `@` an other character, it's used as an operator and can't be part of identifier names.

Fixes #28.
