### PR TITLE
Replace deprecated command

### DIFF
--- a/mmacells.sty
+++ b/mmacells.sty
@@ -642,7 +642,7 @@
     \hbox_set:Nn \@labels
       {
         \skip_horizontal:N \@totalleftmargin
-        \hbox_unpack_clear:N \@labels
+        \hbox_unpack_drop:N \@labels
       }
   }
 


### PR DESCRIPTION
This fixes the following error:

```! LaTeX3 Error: Use \hbox_unpack_drop:N not \hbox_unpack_clear:N deprecated on
(LaTeX3)        2021-01-01. For 6 months after that date one can restore a
(LaTeX3)        deprecated command by loading the expl3 package with the
(LaTeX3)        option 'undo-recent-deprecations'.```