### PR TITLE
Use plain form inner environments

### DIFF
--- a/mmacells.sty
+++ b/mmacells.sty
@@ -419,7 +419,7 @@
     
     \bool_if:NT \l_mmacells_uselist_bool
       {
-        \begin{list}{\box_use:N \l_mmacells_label_box}{
+        \list{\box_use:N \l_mmacells_label_box}{
           \labelsep=\l_mmacells_label_sep_dim
           \leftmargin=\l_mmacells_leftmargin_dim
           \labelwidth=\l_mmacells_label_dim
@@ -439,7 +439,7 @@
   {
     \__mmacells_end_verbatimenv:
     \bool_if:NT \l_mmacells_uselist_bool
-      { \end{list} }
+      { \endlist }
   }
 
 \cs_new_protected:Npn \mmacells_cell_graphics:nnn #1#2#3


### PR DESCRIPTION
Instead of `\begin{list}` and `\end{list}` use `\list` and `\endlist` respectively.

See https://tex.stackexchange.com/a/14684 for general arguments.

Specific reason was that previous version required `\\` after last row when using `tabular` with `collcell` wrapped with `mmaCell` with `verbatimenv=` option, in custom environment. See also https://tex.stackexchange.com/a/83857 .